### PR TITLE
Restore NPC popups on characters page

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -116,84 +116,84 @@
 					These influential figures shape the world around the party—schemers, sages, warlords, and wanderers who cross paths with fate. Some aid, some obstruct, and others blur the line entirely.
 				</p>
 				<div class="npc-gallery">
-					<div class="npc-card">
+                                        <div class="npc-card" onclick="openModal('modal-npc-seraphine')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-lady-seraphine.png" alt="NPC 1" />
 						<div class="npc-info">
 							<h3>Lady Seraphine</h3>
 							<p>Mysterious patron of the party with a veiled past</p>
 						</div>
 					</div>
-					<div class="npc-card">
+                                        <div class="npc-card" onclick="openModal('modal-npc-redmar')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-baron-redmar.png" alt="NPC 2" />
 						<div class="npc-info">
 							<h3>Baron Redmar</h3>
 							<p>Ruthless noble with eyes on the throne</p>
 						</div>
 					</div>
-					<div class="npc-card">
+                                        <div class="npc-card" onclick="openModal('modal-npc-elaris')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-elaris-the-sage.png" alt="NPC 3" />
 						<div class="npc-info">
 							<h3>Elaris the Sage</h3>
 							<p>A cryptic scholar who knows too much</p>
 						</div>
 					</div>
-					<div class="npc-card">
+                                        <div class="npc-card" onclick="openModal('modal-npc-branth')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-captain-branth.png" alt="NPC 4" />
 						<div class="npc-info">
 							<h3>Captain Branth</h3>
 							<p>Gruff mercenary commander with a heart of gold</p>
 						</div>
 					</div>
-					<div class="npc-card">
+                                        <div class="npc-card" onclick="openModal('modal-npc-nyla')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-madame-nyla.png" alt="NPC 5" />
 						<div class="npc-info">
 							<h3>Madame Nyla</h3>
 							<p>Seer of the Wastes with shifting visions of doom</p>
 						</div>
 					</div>
-					<div class="npc-card">
+                                        <div class="npc-card" onclick="openModal('modal-npc-volmir')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-high-arcanist-volmir.png" alt="NPC 6" />
 						<div class="npc-info">
 							<h3>High Arcanist Volmir</h3>
 							<p>Disgraced court mage turned outlaw conjurer</p>
 						</div>
 					</div>
-					<div class="npc-card">
+                                        <div class="npc-card" onclick="openModal('modal-npc-elenwen')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-sister-elenwen.png" alt="NPC 7" />
 						<div class="npc-info">
 							<h3>Sister Elenwen</h3>
 							<p>Wandering healer with a divine secret</p>
 						</div>
 					</div>
-					<div class="npc-card">
+                                        <div class="npc-card" onclick="openModal('modal-npc-gruk')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-gruk-the-unyielding.png" alt="NPC 8" />
 						<div class="npc-info">
 							<h3>Gruk the Unyielding</h3>
 							<p>Orc chieftain with a code of ancient honor</p>
 						</div>
 					</div>
-					<div class="npc-card">
+                                        <div class="npc-card" onclick="openModal('modal-npc-vale')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-inquisitor-vale.png" alt="NPC 9" />
 						<div class="npc-info">
 							<h3>Inquisitor Vale</h3>
 							<p>Fanatical pursuer of heretics and secrets</p>
 						</div>
 					</div>
-					<div class="npc-card">
+                                        <div class="npc-card" onclick="openModal('modal-npc-malric')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-archduke-malric.png" alt="NPC 10" />
 						<div class="npc-info">
 							<h3>Archduke Malric</h3>
 							<p>Diplomatic snake with a velvet tongue</p>
 						</div>
 					</div>
-					<div class="npc-card">
+                                        <div class="npc-card" onclick="openModal('modal-npc-faelan')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-faelan-duskwatch.png" alt="NPC 11" />
 						<div class="npc-info">
 							<h3>Faelan Duskwatch</h3>
 							<p>Silent ranger who watches from the shadows</p>
 						</div>
 					</div>
-					<div class="npc-card">
+                                        <div class="npc-card" onclick="openModal('modal-npc-jinx')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-jinx-whistletoe.png" alt="NPC 12" />
 						<div class="npc-info">
 							<h3>Jinx Whistletoe</h3>
@@ -230,15 +230,100 @@
   </div>
 </section>
 
-			<div id="modal-thorne" class="modal">
-				<div class="modal-content">
-					<span class="close" onclick="closeModal('modal-thorne')">&times;</span>
-					<h2>Thorne Ironfist</h2>
-					<p><strong>Class:</strong> Paladin (Oath of Redemption)</p>
-					<p><strong>Alignment:</strong> Lawful Good (mostly...)</p>
-					<p><strong>Lore:</strong> Once the pride of a mountain clan, Thorne carries the shame of a broken vow. Ale numbs the pain, but his hammer still remembers justice.</p>
-				</div>
-			</div>
+                          <div id="modal-thorne" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-thorne')">&times;</span>
+                                          <h2>Thorne Ironfist</h2>
+                                          <p><strong>Class:</strong> Paladin (Oath of Redemption)</p>
+                                          <p><strong>Alignment:</strong> Lawful Good (mostly...)</p>
+                                          <p><strong>Lore:</strong> Once the pride of a mountain clan, Thorne carries the shame of a broken vow. Ale numbs the pain, but his hammer still remembers justice.</p>
+                                  </div>
+                          </div>
+
+                          <div id="modal-npc-seraphine" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-npc-seraphine')">&times;</span>
+                                          <h2>Lady Seraphine</h2>
+                                          <p>Mysterious patron of the party with a veiled past</p>
+                                  </div>
+                          </div>
+                          <div id="modal-npc-redmar" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-npc-redmar')">&times;</span>
+                                          <h2>Baron Redmar</h2>
+                                          <p>Ruthless noble with eyes on the throne</p>
+                                  </div>
+                          </div>
+                          <div id="modal-npc-elaris" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-npc-elaris')">&times;</span>
+                                          <h2>Elaris the Sage</h2>
+                                          <p>A cryptic scholar who knows too much</p>
+                                  </div>
+                          </div>
+                          <div id="modal-npc-branth" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-npc-branth')">&times;</span>
+                                          <h2>Captain Branth</h2>
+                                          <p>Gruff mercenary commander with a heart of gold</p>
+                                  </div>
+                          </div>
+                          <div id="modal-npc-nyla" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-npc-nyla')">&times;</span>
+                                          <h2>Madame Nyla</h2>
+                                          <p>Seer of the Wastes with shifting visions of doom</p>
+                                  </div>
+                          </div>
+                          <div id="modal-npc-volmir" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-npc-volmir')">&times;</span>
+                                          <h2>High Arcanist Volmir</h2>
+                                          <p>Disgraced court mage turned outlaw conjurer</p>
+                                  </div>
+                          </div>
+                          <div id="modal-npc-elenwen" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-npc-elenwen')">&times;</span>
+                                          <h2>Sister Elenwen</h2>
+                                          <p>Wandering healer with a divine secret</p>
+                                  </div>
+                          </div>
+                          <div id="modal-npc-gruk" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-npc-gruk')">&times;</span>
+                                          <h2>Gruk the Unyielding</h2>
+                                          <p>Orc chieftain with a code of ancient honor</p>
+                                  </div>
+                          </div>
+                          <div id="modal-npc-vale" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-npc-vale')">&times;</span>
+                                          <h2>Inquisitor Vale</h2>
+                                          <p>Fanatical pursuer of heretics and secrets</p>
+                                  </div>
+                          </div>
+                          <div id="modal-npc-malric" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-npc-malric')">&times;</span>
+                                          <h2>Archduke Malric</h2>
+                                          <p>Diplomatic snake with a velvet tongue</p>
+                                  </div>
+                          </div>
+                          <div id="modal-npc-faelan" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-npc-faelan')">&times;</span>
+                                          <h2>Faelan Duskwatch</h2>
+                                          <p>Silent ranger who watches from the shadows</p>
+                                  </div>
+                          </div>
+                          <div id="modal-npc-jinx" class="modal">
+                                  <div class="modal-content">
+                                          <span class="close" onclick="closeModal('modal-npc-jinx')">&times;</span>
+                                          <h2>Jinx Whistletoe</h2>
+                                          <p>Cheerful halfling informant who knows everybody</p>
+                                  </div>
+                          </div>
 
 			<script>
 				function openModal(id) {


### PR DESCRIPTION
## Summary
- enable modal popups for every NPC card
- add hidden modal content for each NPC with short description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c5b59b5508333ae6e8223fa5a6e52