### PR TITLE
Restore NPC popups

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -116,84 +116,84 @@
 					These influential figures shape the world around the party—schemers, sages, warlords, and wanderers who cross paths with fate. Some aid, some obstruct, and others blur the line entirely.
 				</p>
 				<div class="npc-gallery">
-                                        <div class="npc-card" onclick="openModal('modal-npc-seraphine')">
+                                        <div class="npc-card" onclick="openModal('modal-npc-seraphine')" onmouseenter="openModal('modal-npc-seraphine')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-lady-seraphine.png" alt="NPC 1" />
 						<div class="npc-info">
 							<h3>Lady Seraphine</h3>
 							<p>Mysterious patron of the party with a veiled past</p>
 						</div>
 					</div>
-                                        <div class="npc-card" onclick="openModal('modal-npc-redmar')">
+                                        <div class="npc-card" onclick="openModal('modal-npc-redmar')" onmouseenter="openModal('modal-npc-redmar')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-baron-redmar.png" alt="NPC 2" />
 						<div class="npc-info">
 							<h3>Baron Redmar</h3>
 							<p>Ruthless noble with eyes on the throne</p>
 						</div>
 					</div>
-                                        <div class="npc-card" onclick="openModal('modal-npc-elaris')">
+                                        <div class="npc-card" onclick="openModal('modal-npc-elaris')" onmouseenter="openModal('modal-npc-elaris')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-elaris-the-sage.png" alt="NPC 3" />
 						<div class="npc-info">
 							<h3>Elaris the Sage</h3>
 							<p>A cryptic scholar who knows too much</p>
 						</div>
 					</div>
-                                        <div class="npc-card" onclick="openModal('modal-npc-branth')">
+                                        <div class="npc-card" onclick="openModal('modal-npc-branth')" onmouseenter="openModal('modal-npc-branth')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-captain-branth.png" alt="NPC 4" />
 						<div class="npc-info">
 							<h3>Captain Branth</h3>
 							<p>Gruff mercenary commander with a heart of gold</p>
 						</div>
 					</div>
-                                        <div class="npc-card" onclick="openModal('modal-npc-nyla')">
+                                        <div class="npc-card" onclick="openModal('modal-npc-nyla')" onmouseenter="openModal('modal-npc-nyla')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-madame-nyla.png" alt="NPC 5" />
 						<div class="npc-info">
 							<h3>Madame Nyla</h3>
 							<p>Seer of the Wastes with shifting visions of doom</p>
 						</div>
 					</div>
-                                        <div class="npc-card" onclick="openModal('modal-npc-volmir')">
+                                        <div class="npc-card" onclick="openModal('modal-npc-volmir')" onmouseenter="openModal('modal-npc-volmir')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-high-arcanist-volmir.png" alt="NPC 6" />
 						<div class="npc-info">
 							<h3>High Arcanist Volmir</h3>
 							<p>Disgraced court mage turned outlaw conjurer</p>
 						</div>
 					</div>
-                                        <div class="npc-card" onclick="openModal('modal-npc-elenwen')">
+                                        <div class="npc-card" onclick="openModal('modal-npc-elenwen')" onmouseenter="openModal('modal-npc-elenwen')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-sister-elenwen.png" alt="NPC 7" />
 						<div class="npc-info">
 							<h3>Sister Elenwen</h3>
 							<p>Wandering healer with a divine secret</p>
 						</div>
 					</div>
-                                        <div class="npc-card" onclick="openModal('modal-npc-gruk')">
+                                        <div class="npc-card" onclick="openModal('modal-npc-gruk')" onmouseenter="openModal('modal-npc-gruk')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-gruk-the-unyielding.png" alt="NPC 8" />
 						<div class="npc-info">
 							<h3>Gruk the Unyielding</h3>
 							<p>Orc chieftain with a code of ancient honor</p>
 						</div>
 					</div>
-                                        <div class="npc-card" onclick="openModal('modal-npc-vale')">
+                                        <div class="npc-card" onclick="openModal('modal-npc-vale')" onmouseenter="openModal('modal-npc-vale')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-inquisitor-vale.png" alt="NPC 9" />
 						<div class="npc-info">
 							<h3>Inquisitor Vale</h3>
 							<p>Fanatical pursuer of heretics and secrets</p>
 						</div>
 					</div>
-                                        <div class="npc-card" onclick="openModal('modal-npc-malric')">
+                                        <div class="npc-card" onclick="openModal('modal-npc-malric')" onmouseenter="openModal('modal-npc-malric')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-archduke-malric.png" alt="NPC 10" />
 						<div class="npc-info">
 							<h3>Archduke Malric</h3>
 							<p>Diplomatic snake with a velvet tongue</p>
 						</div>
 					</div>
-                                        <div class="npc-card" onclick="openModal('modal-npc-faelan')">
+                                        <div class="npc-card" onclick="openModal('modal-npc-faelan')" onmouseenter="openModal('modal-npc-faelan')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-faelan-duskwatch.png" alt="NPC 11" />
 						<div class="npc-info">
 							<h3>Faelan Duskwatch</h3>
 							<p>Silent ranger who watches from the shadows</p>
 						</div>
 					</div>
-                                        <div class="npc-card" onclick="openModal('modal-npc-jinx')">
+                                        <div class="npc-card" onclick="openModal('modal-npc-jinx')" onmouseenter="openModal('modal-npc-jinx')">
 						<img loading="lazy" src="https://raw.githubusercontent.com/picsterola/dnd-site/main/npcs/npc-jinx-whistletoe.png" alt="NPC 12" />
 						<div class="npc-info">
 							<h3>Jinx Whistletoe</h3>


### PR DESCRIPTION
## Summary
- show NPC info popups on hover or click just like the character roster

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c8bac071c8333b96c4c86dc71e530